### PR TITLE
댓글 관련 예외 처리 개선 및 API 응답 메시지 수정

### DIFF
--- a/src/main/java/com/findora/findora/comment/controller/CommentController.java
+++ b/src/main/java/com/findora/findora/comment/controller/CommentController.java
@@ -77,10 +77,10 @@ public class CommentController {
     @Operation(summary = "댓글 삭제", description = "댓글을 삭제합니다. 본인이 작성한 댓글만 삭제 가능합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "댓글 삭제 성공"),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 (댓글이 해당 게시글에 속하지 않음)"),
             @ApiResponse(responseCode = "401", description = "인증 필요"),
             @ApiResponse(responseCode = "403", description = "권한 없음 (본인 댓글이 아님)"),
-            @ApiResponse(responseCode = "404", description = "댓글을 찾을 수 없음")
+            @ApiResponse(responseCode = "404", description = "게시글 또는 댓글을 찾을 수 없음 (존재하지 않거나 이미 삭제됨)")
     })
     @DeleteMapping("/{id}")
     @SecurityRequirement(name = "Authorization")

--- a/src/main/java/com/findora/findora/comment/service/CommentService.java
+++ b/src/main/java/com/findora/findora/comment/service/CommentService.java
@@ -15,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.*;
 import org.springframework.stereotype.Service;
 
+import jakarta.persistence.EntityNotFoundException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -34,15 +35,15 @@ public class CommentService {
     @Transactional
     public SuccessResponse createComment(Long postId, Long userId, CommentRequestDto dto) {
         Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new IllegalArgumentException("게시글이 존재하지 않습니다. id=" + postId));
+                .orElseThrow(() -> new EntityNotFoundException("게시글이 존재하지 않습니다. id=" + postId));
 
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("사용자가 존재하지 않습니다. id=" + userId));
+                .orElseThrow(() -> new EntityNotFoundException("사용자가 존재하지 않습니다. id=" + userId));
 
         Comment parent = null;
         if (dto.getParentId() != null) {
             parent = commentRepository.findById(dto.getParentId())
-                    .orElseThrow(() -> new IllegalArgumentException("부모 댓글이 존재하지 않습니다. id=" + dto.getParentId()));
+                    .orElseThrow(() -> new EntityNotFoundException("부모 댓글이 존재하지 않습니다. id=" + dto.getParentId()));
         }
 
         Comment comment = Comment.builder()
@@ -83,11 +84,11 @@ public class CommentService {
     public SuccessResponse updateComment(Long postId, Long commentId, Long userId, CommentUpdateRequestDto dto) {
         // 게시글 존재 여부 확인
         Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new IllegalArgumentException("게시글이 존재하지 않습니다. id=" + postId));
+                .orElseThrow(() -> new EntityNotFoundException("게시글이 존재하지 않습니다. id=" + postId));
         
         Comment comment = commentRepository.findById(commentId)
                 .filter(c -> !c.getIsDeleted()) //삭제 상태인 댓글
-                .orElseThrow(() -> new IllegalArgumentException("댓글이 존재하지 않습니다. id=" + commentId));
+                .orElseThrow(() -> new EntityNotFoundException("댓글이 존재하지 않습니다. id=" + commentId));
         
         // 댓글이 해당 게시글에 속하는지 확인
         if (!comment.getPost().getId().equals(postId)) {
@@ -109,14 +110,14 @@ public class CommentService {
     public SuccessResponse deleteComment(Long postId, Long commentId, Long userId) {
         // 게시글 존재 여부 확인
         Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new IllegalArgumentException("게시글이 존재하지 않습니다. id=" + postId));
+                .orElseThrow(() -> new EntityNotFoundException("게시글이 존재하지 않습니다. id=" + postId));
         
         Comment comment = commentRepository.findById(commentId)
-                .orElseThrow(() -> new IllegalArgumentException("댓글이 존재하지 않습니다. id=" + commentId));
+                .orElseThrow(() -> new EntityNotFoundException("댓글이 존재하지 않습니다. id=" + commentId));
 
         // 이미 삭제된 댓글인지 확인
         if (comment.getIsDeleted()) {
-            throw new IllegalArgumentException("이미 삭제된 댓글입니다. id=" + commentId);
+            throw new EntityNotFoundException("이미 삭제된 댓글입니다. id=" + commentId);
         }
 
         // 댓글이 해당 게시글에 속하는지 확인

--- a/src/main/java/com/findora/findora/common/GlobalExceptionHandler.java
+++ b/src/main/java/com/findora/findora/common/GlobalExceptionHandler.java
@@ -9,12 +9,23 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.bind.annotation.RestController;
 
+import jakarta.persistence.EntityNotFoundException;
 import java.time.LocalDateTime;
 import java.util.Map;
 import jakarta.servlet.http.HttpServletRequest;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity<?> handleEntityNotFound(EntityNotFoundException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(
+            Map.of(
+                "error", ex.getMessage(),
+                "timestamp", LocalDateTime.now()
+            )
+        );
+    }
 
     @ExceptionHandler(BadCredentialsException.class)
     public ResponseEntity<?> handleBadCredentials(BadCredentialsException ex) {


### PR DESCRIPTION
- 댓글 삭제 API의 응답 메시지를 구체화하여 잘못된 요청 및 댓글 찾기 실패 시의 설명 추가
- CommentService에서 IllegalArgumentException을 EntityNotFoundException으로 변경하여 예외 처리 일관성 강화
- GlobalExceptionHandler에 EntityNotFoundException 처리 메서드 추가