### PR TITLE
댓글 및 게시글 모델 리팩토링 및 소프트 삭제 기능 추가

### DIFF
--- a/src/main/java/com/findora/findora/comment/dto/CommentResponseDto.java
+++ b/src/main/java/com/findora/findora/comment/dto/CommentResponseDto.java
@@ -39,10 +39,10 @@ public class CommentResponseDto {
                 .id(comment.getId())
                 .parentId(comment.getParent() != null ? comment.getParent().getId() : null)
                 .postId(comment.getPost().getId()) //post에서 ID를 가져옴
-                .content(comment.getIsDeleted() ? "(삭제된 댓글입니다)" : comment.getContent())
+                .content(comment.isDeleted() ? "(삭제된 댓글입니다)" : comment.getContent())
                 .createdAt(comment.getCreatedAt())
                 .updatedAt(comment.getUpdatedAt())
-                .isDeleted(comment.getIsDeleted())
+                .isDeleted(comment.isDeleted())
                 .build();
     }
 }

--- a/src/main/java/com/findora/findora/comment/model/Comment.java
+++ b/src/main/java/com/findora/findora/comment/model/Comment.java
@@ -1,22 +1,24 @@
 package com.findora.findora.comment.model;
 
-import com.findora.findora.users.model.User;
+import com.findora.findora.common.BaseEntity;
 import com.findora.findora.posts.model.Post;
+import com.findora.findora.users.model.User;
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "comment")
+@SQLDelete(sql = "UPDATE comment SET deleted = true, updated_at = NOW() WHERE id = ?")
+@Where(clause = "deleted = false")
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
-public class Comment {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+@SuperBuilder
+public class Comment extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
@@ -33,34 +35,12 @@ public class Comment {
     @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
 
-    @Column(name = "created_at", nullable = false)
-    private LocalDateTime createdAt;
-
-    @Column(name = "updated_at")
-    private LocalDateTime updatedAt;
-
-    //삭제상태표시 필드 추가
-    @Column(name = "is_deleted", nullable = false)
-    private Boolean isDeleted = false;  // 삭제 여부 (기본값 false)
-
-    @PrePersist
-    protected void onCreate() {
-        this.createdAt = LocalDateTime.now();
-    }
-
-    @PreUpdate
-    protected void onUpdate() {
-        this.updatedAt = LocalDateTime.now();
-    }
-
     public void updateContent(String content) {
         this.content = content;
     }
 
-    //삭제표시
-    /*외래키 제약 조건떄문에 오류가 발생하여 추가함*/
+    //삭제표시 (BaseEntity의 markAsDeleted 메서드 사용)
     public void markAsDeleted() {
-        this.isDeleted = true;
+        super.markAsDeleted(); // BaseEntity의 markAsDeleted() 호출
     }
-
 }

--- a/src/main/java/com/findora/findora/comment/repository/CommentRepository.java
+++ b/src/main/java/com/findora/findora/comment/repository/CommentRepository.java
@@ -2,6 +2,8 @@ package com.findora.findora.comment.repository;
 
 import com.findora.findora.comment.model.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -9,8 +11,12 @@ import java.util.List;
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
-    // 삭제되지 않은 댓글만 불러오는 메서드 추가
-    List<Comment> findByPostIdAndIsDeletedFalse(Long postId);
-    List<Comment> findByParentIdAndIsDeletedFalse(Long parentId);
+    // 삭제되지 않은 댓글만 불러오는 메서드 (BaseEntity의 deleted 필드 사용)
+    List<Comment> findByPostIdAndDeletedFalse(Long postId);
+    List<Comment> findByParentIdAndDeletedFalse(Long parentId);
+
+    // 삭제된 댓글도 포함해서 조회하는 메서드 (@Where 어노테이션 무시)
+    @Query(value = "SELECT * FROM comment WHERE post_id = :postId ORDER BY created_at ASC", nativeQuery = true)
+    List<Comment> findByPostIdIncludingDeleted(@Param("postId") Long postId);
 
 }

--- a/src/main/java/com/findora/findora/comment/service/CommentService.java
+++ b/src/main/java/com/findora/findora/comment/service/CommentService.java
@@ -51,7 +51,6 @@ public class CommentService {
                 .user(user)
                 .parent(parent)
                 .content(dto.getContent())
-                .isDeleted(false)
                 .build();
 
         commentRepository.save(comment);
@@ -59,10 +58,11 @@ public class CommentService {
         return SuccessResponse.of("댓글이 성공적으로 등록되었습니다.");
     }
 
-    //게시글 ID로 댓글 조회(논리 삭제된 댓글 제외)
+    //게시글 ID로 댓글 조회(삭제된 댓글도 포함, 삭제된 댓글은 내용을 "삭제된 댓글입니다"로 표시)
     @Transactional(readOnly = true)
     public List<CommentResponseDto> getCommentsByPostId(Long postId) {
-        List<Comment> comments = commentRepository.findByPostIdAndIsDeletedFalse(postId);
+        // 삭제된 댓글도 포함해서 조회 (네이티브 쿼리로 @Where 어노테이션 무시)
+        List<Comment> comments = commentRepository.findByPostIdIncludingDeleted(postId);
 
         return comments.stream()
                 .map(CommentResponseDto::fromEntity)
@@ -86,8 +86,8 @@ public class CommentService {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new EntityNotFoundException("게시글이 존재하지 않습니다. id=" + postId));
         
+        // @Where 어노테이션으로 자동 필터링되므로 isDeleted() 체크 불필요
         Comment comment = commentRepository.findById(commentId)
-                .filter(c -> !c.getIsDeleted()) //삭제 상태인 댓글
                 .orElseThrow(() -> new EntityNotFoundException("댓글이 존재하지 않습니다. id=" + commentId));
         
         // 댓글이 해당 게시글에 속하는지 확인
@@ -112,13 +112,9 @@ public class CommentService {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new EntityNotFoundException("게시글이 존재하지 않습니다. id=" + postId));
         
+        // @Where 어노테이션으로 자동 필터링되므로 isDeleted() 체크 불필요
         Comment comment = commentRepository.findById(commentId)
                 .orElseThrow(() -> new EntityNotFoundException("댓글이 존재하지 않습니다. id=" + commentId));
-
-        // 이미 삭제된 댓글인지 확인
-        if (comment.getIsDeleted()) {
-            throw new EntityNotFoundException("이미 삭제된 댓글입니다. id=" + commentId);
-        }
 
         // 댓글이 해당 게시글에 속하는지 확인
         if (!comment.getPost().getId().equals(postId)) {

--- a/src/main/java/com/findora/findora/common/BaseEntity.java
+++ b/src/main/java/com/findora/findora/common/BaseEntity.java
@@ -1,0 +1,56 @@
+package com.findora.findora.common;
+
+import java.time.LocalDateTime;
+
+import org.hibernate.annotations.CreationTimestamp;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.PreUpdate;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@MappedSuperclass
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@SuperBuilder
+public abstract class BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted", nullable = false)
+    @Builder.Default
+    protected boolean deleted = false;
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    // 소프트 삭제 메서드 (하위 클래스에서 사용 가능)
+    protected void markAsDeleted() {
+        this.deleted = true;
+    }
+
+    // 소프트 삭제 확인 메서드
+    public boolean isDeleted() {
+        return this.deleted;
+    }
+} 

--- a/src/main/java/com/findora/findora/posts/controller/PostController.java
+++ b/src/main/java/com/findora/findora/posts/controller/PostController.java
@@ -409,6 +409,6 @@ public class PostController {
         @Parameter(description = "삭제할 게시글 ID", example = "15", required = true)
         @PathVariable Long id
     ) {
-        return ResponseEntity.ok(postService.deletePost(id, user.getId()));
+        return ResponseEntity.ok(postService.softDeletePost(id, user.getId()));
     }
 }

--- a/src/main/java/com/findora/findora/posts/model/Post.java
+++ b/src/main/java/com/findora/findora/posts/model/Post.java
@@ -3,6 +3,7 @@ package com.findora.findora.posts.model;
 import java.time.LocalDateTime;
 
 import com.findora.findora.categories.model.Category;
+import com.findora.findora.common.BaseEntity;
 import com.findora.findora.users.model.User;
 
 import jakarta.persistence.Column;
@@ -21,18 +22,19 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @Entity
 @Table(name = "posts")
+@SQLDelete(sql = "UPDATE posts SET deleted = true, updated_at = NOW() WHERE id = ?")
+@Where(clause = "deleted = false")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Builder
-
-public class Post {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+@SuperBuilder
+public class Post extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "category_id", nullable = false)
@@ -52,23 +54,11 @@ public class Post {
     @Builder.Default
     private Long viewCount = 0L;
 
-    @Column(name = "created_at", nullable = false, updatable = false)
-    private LocalDateTime createdAt;
-
-    @Column(name = "updated_at")
-    private LocalDateTime updatedAt;
-
     @PrePersist
     protected void onCreate() {
-        this.createdAt = LocalDateTime.now();
         if (this.viewCount == null) {
             this.viewCount = 0L;
         }
-    }
-
-    @PreUpdate
-    protected void onUpdate() {
-        this.updatedAt = LocalDateTime.now();
     }
 
     public void update(String title, String content, Category category) {

--- a/src/main/java/com/findora/findora/posts/service/PostService.java
+++ b/src/main/java/com/findora/findora/posts/service/PostService.java
@@ -78,13 +78,13 @@ public class PostService {
     }
 
     @Transactional
-    public SuccessResponse deletePost(Long id, Long userId) {
+    public SuccessResponse softDeletePost(Long id, Long userId) {
         Post post = postRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("게시글이 없습니다: " + id));
         if (!post.getUser().getId().equals(userId)) {
             throw new SecurityException("작성자만 삭제할 수 있습니다.");
         }
-        postRepository.deleteById(id);
+        postRepository.delete(post);
         return SuccessResponse.of("게시글 삭제 성공하였습니다.");
     }
 }

--- a/src/main/java/com/findora/findora/users/controller/UserController.java
+++ b/src/main/java/com/findora/findora/users/controller/UserController.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.Map;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -14,10 +16,12 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.findora.findora.agreement.dto.AgreementRequestDTO;
+import com.findora.findora.common.SuccessResponse;
 import com.findora.findora.emailverification.service.EmailVerificationService;
 import com.findora.findora.users.dto.UserRegisterRequestDTO;
 import com.findora.findora.users.model.User;
 import com.findora.findora.users.repository.UserRepository;
+import com.findora.findora.users.service.CustomUserDetails;
 import com.findora.findora.users.service.UserService;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -26,6 +30,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
@@ -200,5 +205,18 @@ public class UserController {
         }
     }
     
-    
+    @Operation(summary = "회원 탈퇴", description = "현재 로그인한 사용자의 계정을 삭제합니다. (소프트 삭제)")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "회원 탈퇴 성공",
+            content = @Content(mediaType = "application/json",
+                examples = @ExampleObject(value = "{\"message\": \"사용자가 성공적으로 삭제되었습니다.\"}"))),
+        @ApiResponse(responseCode = "401", description = "인증 필요"),
+        @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
+    })
+    @DeleteMapping("/me")
+    @SecurityRequirement(name = "Authorization")
+    public ResponseEntity<SuccessResponse> deleteMyAccount(
+            @AuthenticationPrincipal CustomUserDetails user) {
+        return ResponseEntity.ok(userService.softDeleteUser(user.getId()));
+    }
 } 

--- a/src/main/java/com/findora/findora/users/model/User.java
+++ b/src/main/java/com/findora/findora/users/model/User.java
@@ -3,6 +3,10 @@ package com.findora.findora.users.model;
 import java.time.LocalDateTime;
 
 import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
+import com.findora.findora.common.BaseEntity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -18,6 +22,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 @Entity
 @Table(name = "users",
@@ -25,15 +30,13 @@ import lombok.NoArgsConstructor;
          @UniqueConstraint(name = "uk_users_email",    columnNames = "email"),
          @UniqueConstraint(name = "uk_users_nickname", columnNames = "nickname")
        })
+@SQLDelete(sql = "UPDATE users SET deleted = true, updated_at = NOW() WHERE id = ?")
+@Where(clause = "deleted = false")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Builder
-public class User {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+@SuperBuilder
+public class User extends BaseEntity {
 
     @Column(name = "login_id", nullable = false, length = 50)
     private String loginId;
@@ -50,10 +53,6 @@ public class User {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 10)
     private Role role;
-
-    @CreationTimestamp
-    @Column(name = "created_at", nullable = false, updatable = false)
-    private LocalDateTime createdAt;
 
     @Column(name = "email_verified", nullable = false)
     private boolean emailVerified;

--- a/src/main/java/com/findora/findora/users/service/UserService.java
+++ b/src/main/java/com/findora/findora/users/service/UserService.java
@@ -13,11 +13,13 @@ import com.findora.findora.agreement.model.AgreementType;
 import com.findora.findora.agreement.model.UserAgreement;
 import com.findora.findora.agreement.repository.UserAgreementRepository;
 import com.findora.findora.common.email.EmailSender;
+import com.findora.findora.common.SuccessResponse;
 import com.findora.findora.emailverification.service.EmailVerificationService;
 import com.findora.findora.users.dto.UserRegisterRequestDTO;
 import com.findora.findora.users.model.User;
 import com.findora.findora.users.repository.UserRepository;
 
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -30,6 +32,7 @@ public class UserService {
     private final EmailVerificationService emailVerificationService;
     private final EmailSender emailSender;
     private final UserAgreementRepository userAgreementRepository;
+    
     // 사용자 등록
     @Transactional
     public User registerUser(UserRegisterRequestDTO userRegisterRequestDTO) {
@@ -41,6 +44,11 @@ public class UserService {
         if (userRepository.existsByNickname(userRegisterRequestDTO.getNickname())) {
             throw new IllegalArgumentException("이미 존재하는 닉네임입니다.");
         }
+        
+        if (userRepository.existsByLoginId(userRegisterRequestDTO.getLoginId())) {
+            throw new IllegalArgumentException("이미 존재하는 로그인 ID입니다.");
+        }
+        
         if (!emailVerificationService.isVerified(userRegisterRequestDTO.getEmail())) {
             throw new IllegalArgumentException("이메일 인증이 필요합니다.");
         }
@@ -91,7 +99,7 @@ public class UserService {
     @Transactional
     public void verifyEmail(Long userId) {
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+                .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
         user.verifyEmail();
     }
     
@@ -99,7 +107,7 @@ public class UserService {
     @Transactional
     public void changePassword(Long userId, String newPassword) {
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+                .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
         String encodedPassword = passwordEncoder.encode(newPassword);
         user.changePassword(encodedPassword);
     }
@@ -112,16 +120,30 @@ public class UserService {
         }
         
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+                .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
         user.changeNickname(newNickname);
     }
     
+    // 로그인
     public User login(String loginId, String password) {
         User user = userRepository.findByLoginId(loginId)
-                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+                .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
         if (!passwordEncoder.matches(password, user.getPassword())) {
             throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
         }
         return user;
+    }
+    
+    // 소프트 삭제 (JPA delete 메서드 사용)
+    @Transactional
+    public SuccessResponse softDeleteUser(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
+        
+        // JPA delete 메서드 호출 시 @SQLDelete 어노테이션으로 인해 
+        // 실제로는 UPDATE users SET deleted = true WHERE id = ? 가 실행됨
+        userRepository.delete(user);
+        
+        return SuccessResponse.of("사용자가 성공적으로 삭제되었습니다.");
     }
 } 


### PR DESCRIPTION
- Comment 및 Post 모델에 BaseEntity를 상속받아 공통 필드 및 메서드 통합
- 댓글 및 게시글의 삭제 상태를 관리하기 위해 @SQLDelete 및 @Where 어노테이션 추가
- 댓글 조회 시 삭제된 댓글도 포함하여 표시하도록 수정
- 사용자 계정 소프트 삭제 기능 추가 및 관련 API 구현
- 예외 처리 일관성을 위해 EntityNotFoundException 사용으로 변경