### PR TITLE
게시글 삭제 시 관련 댓글을 소프트 삭제하는 기능 추가

### DIFF
--- a/src/main/java/com/findora/findora/comment/service/CommentService.java
+++ b/src/main/java/com/findora/findora/comment/service/CommentService.java
@@ -138,4 +138,16 @@ public class CommentService {
                 .map(CommentResponseDto::fromEntity)
                 .collect(Collectors.toList());
     }
+
+    //게시글 ID로 모든 댓글 소프트 삭제 (게시글 삭제 시 사용)
+    @Transactional
+    public void deleteAllCommentsByPostId(Long postId) {
+        // 해당 게시글의 모든 댓글 조회 (삭제되지 않은 댓글만)
+        List<Comment> comments = commentRepository.findByPostIdAndDeletedFalse(postId);
+        
+        // 모든 댓글을 소프트 삭제
+        for (Comment comment : comments) {
+            comment.markAsDeleted();
+        }
+    }
 }

--- a/src/main/java/com/findora/findora/posts/service/PostService.java
+++ b/src/main/java/com/findora/findora/posts/service/PostService.java
@@ -15,6 +15,7 @@ import com.findora.findora.posts.repository.PostRepository;
 import com.findora.findora.users.model.User;
 import com.findora.findora.users.repository.UserRepository;
 import com.findora.findora.common.SuccessResponse;
+import com.findora.findora.comment.service.CommentService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -26,6 +27,7 @@ public class PostService {
     private final PostRepository postRepository;
     private final CategoryRepository categoryRepository;
     private final UserRepository userRepository;
+    private final CommentService commentService;
 
     @Transactional
     public SuccessResponse createPost(PostRequestDto requestDto, Long userId) {
@@ -84,6 +86,11 @@ public class PostService {
         if (!post.getUser().getId().equals(userId)) {
             throw new SecurityException("작성자만 삭제할 수 있습니다.");
         }
+        
+        // 관련 댓글들을 먼저 삭제
+        commentService.deleteAllCommentsByPostId(id);
+        
+        // 게시글 삭제
         postRepository.delete(post);
         return SuccessResponse.of("게시글 삭제 성공하였습니다.");
     }


### PR DESCRIPTION
- PostService에서 게시글 삭제 시 CommentService를 호출하여 해당 게시글의 모든 댓글을 소프트 삭제하도록 구현
- CommentService에 게시글 ID로 모든 댓글을 소프트 삭제하는 메서드 추가