### PR TITLE
게시글 응답 DTO에서 사용자 정보 안전 처리 로직 추가

### DIFF
--- a/src/main/java/com/findora/findora/posts/dto/PostResponseDto.java
+++ b/src/main/java/com/findora/findora/posts/dto/PostResponseDto.java
@@ -45,6 +45,15 @@ public class PostResponseDto {
 
     // Entity → DTO 변환 메서드
     public static PostResponseDto fromEntity(Post post) {
+        // 사용자 정보 안전하게 가져오기
+        Long userId = null;
+        String userNickname = "탈퇴한 사용자";
+        
+        if (post.getUser() != null && !post.getUser().isDeleted()) {
+            userId = post.getUser().getId();
+            userNickname = post.getUser().getNickname();
+        }
+        
         return PostResponseDto.builder()
                 .id(post.getId())
                 .title(post.getTitle())
@@ -53,8 +62,8 @@ public class PostResponseDto {
                 .createdAt(post.getCreatedAt())
                 .updatedAt(post.getUpdatedAt())
                 .category(CategoryResponseDto.fromEntity(post.getCategory()))
-                .userId(post.getUser().getId())
-                .userNickname(post.getUser().getNickname())
+                .userId(userId)
+                .userNickname(userNickname)
                 .build();
     }
     /*userid

--- a/src/main/java/com/findora/findora/posts/model/Post.java
+++ b/src/main/java/com/findora/findora/posts/model/Post.java
@@ -25,6 +25,8 @@ import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
+import org.hibernate.annotations.NotFound;
+import org.hibernate.annotations.NotFoundAction;
 
 @Entity
 @Table(name = "posts")
@@ -42,6 +44,7 @@ public class Post extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
+    @NotFound(action = NotFoundAction.IGNORE)
     private User user;
 
     @Column(nullable = false, length = 200)


### PR DESCRIPTION
- 사용자 정보가 삭제된 경우 기본값으로 "탈퇴한 사용자"를 설정하도록 수정
- 사용자 정보가 존재하지 않거나 삭제된 경우를 처리하기 위해 @NotFound 어노테이션 추가