### PR TITLE
게시글 응답 DTO 및 서비스에서 사용자 정보 로딩 오류 처리 추가

### DIFF
--- a/src/main/java/com/findora/findora/posts/dto/PostResponseDto.java
+++ b/src/main/java/com/findora/findora/posts/dto/PostResponseDto.java
@@ -49,9 +49,15 @@ public class PostResponseDto {
         Long userId = null;
         String userNickname = "탈퇴한 사용자";
         
-        if (post.getUser() != null && !post.getUser().isDeleted()) {
-            userId = post.getUser().getId();
-            userNickname = post.getUser().getNickname();
+        try {
+            if (post.getUser() != null && !post.getUser().isDeleted()) {
+                userId = post.getUser().getId();
+                userNickname = post.getUser().getNickname();
+            }
+        } catch (Exception e) {
+            // User 로딩 실패 시 기본값 유지
+            userId = null;
+            userNickname = "탈퇴한 사용자";
         }
         
         return PostResponseDto.builder()

--- a/src/main/java/com/findora/findora/posts/model/Post.java
+++ b/src/main/java/com/findora/findora/posts/model/Post.java
@@ -43,7 +43,7 @@ public class Post extends BaseEntity {
     private Category category;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
+    @JoinColumn(name = "user_id", nullable = false, updatable = false)
     @NotFound(action = NotFoundAction.IGNORE)
     private User user;
 

--- a/src/main/java/com/findora/findora/posts/service/PostService.java
+++ b/src/main/java/com/findora/findora/posts/service/PostService.java
@@ -56,7 +56,12 @@ public class PostService {
         // 조회수 증가
         post.incrementViewCount();
         
-        return PostResponseDto.fromEntity(post);
+        try {
+            return PostResponseDto.fromEntity(post);
+        } catch (Exception e) {
+            // 탈퇴한 사용자로 인한 오류 발생 시 안전하게 처리
+            throw new RuntimeException("게시글 조회 중 오류가 발생했습니다: " + e.getMessage(), e);
+        }
     }
 
     public List<PostResponseDto> getPostsByCategory(Long categoryId) {


### PR DESCRIPTION
- 사용자 정보 로딩 중 예외 발생 시 기본값 유지하도록 수정
- 게시글 조회 시 사용자 정보 로딩 실패 시 안전하게 처리하는 로직 추가
- Post 모델에서 user_id 컬럼의 업데이트 불가 설정 추가